### PR TITLE
Remove likely cause of ImGUI error in recent REF versions

### DIFF
--- a/reframework/autorun/randomizer/GUI.lua
+++ b/reframework/autorun/randomizer/GUI.lua
@@ -53,7 +53,6 @@ function GUI.CheckForAndDisplayMessages()
     imgui.pop_style_var(1)
     imgui.pop_font()
     imgui.end_window()
-    imgui.end_window()
 end
 
 function GUI.AddText(message, color, index)


### PR DESCRIPTION
Found a duplicate end_window call in RE2R's client which made it into the others. Removing this had no apparent effect in RE2R, so sending over the same fix here too.